### PR TITLE
Persist settings and fix view crash

### DIFF
--- a/fuel_config.json
+++ b/fuel_config.json
@@ -1,1 +1,13 @@
-{"rpm_channel": "RPMX1", "etasp_channel": "ETASP", "filters": []}
+{
+  "rpm_channel": "RPMX1",
+  "etasp_channel": "ETASP",
+  "filters": [],
+  "csv_columns": {
+    "x_column": "RPM",
+    "y_column": "ETASP",
+    "z_column": "Fuel_Consumption",
+    "etasp_min": 0.0,
+    "etasp_max": 1.0,
+    "etasp_intervals": 50
+  }
+}


### PR DESCRIPTION
Implement persistence for CSV column selections and fix `QApplication` threading issues.

The previous approach of creating new `QApplication` instances in separate threads for each surface table viewer led to "QApplication was not created in the main() thread" warnings and program crashes. This PR ensures `QApplication` is initialized once on the main thread and manages viewer instances globally to prevent these issues, while also saving user-selected CSV column configurations.

---

[Open in Web](https://www.cursor.com/agents?id=bc-ba224ede-da0d-49c1-a2e4-3ce3eb6f06c8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ba224ede-da0d-49c1-a2e4-3ce3eb6f06c8)